### PR TITLE
Fix initial nodes.

### DIFF
--- a/src/Flowchart.tsx
+++ b/src/Flowchart.tsx
@@ -65,7 +65,7 @@ const initialEdges: Edge[] = [
   },
 ];
 
-let id = 0;
+let id = 4;
 const getId = () => `dndnode_${id++}`;
 
 const Flowchart = () => {


### PR DESCRIPTION
We initialize with nodes up to id 3, but create new nodes with ID 0.

This means the first few nodes we create overwrite existing nodes!